### PR TITLE
Docker env variable to add custom options to the Caddyfile

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -46,6 +46,17 @@ You can control most of Kafka Topics UI settings via environment variables:
 `MAX_BYTES` (default 50000), `RECORD_POLL_TIMEOUT` (default 2000),
 `DEBUG_LOGS_ENABLED` (default true).
 
+## Caddy options
+
+If you are using the internal Caddy proxy to contact the REST proxy, you can apply further configuration via the environment variable `CADDY_OPTIONS`.
+
+### CADDY_OPTIONS
+
+For instance, if you want to disable timeouts, you can do so via the caddy options:
+
+    docker run --rm -it -p 8000:8000 \
+               -e "CADDY_OPTIONS=timeouts none" \
+               landoop/kafka-topics-ui
 
 # Kafka REST Proxy Configuration
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,6 +5,7 @@ MAX_BYTES="${MAX_BYTES:-50000}"
 RECORD_POLL_TIMEOUT="${RECORD_POLL_TIMEOUT:-2000}"
 DEBUG_LOGS_ENABLED="${DEBUG_LOGS_ENABLED:-true}"
 INSECURE_PROXY=""
+CADDY_OPTIONS="${CADDY_OPTIONS:-}"
 EXPERIMENTAL_PROXY_URL="${EXPERIMENTAL_PROXY_URL:-false}"
 
 cat /caddy/Caddyfile.template > /caddy/Caddyfile
@@ -44,6 +45,13 @@ var clusters = [
      DEBUG_LOGS_ENABLED: $DEBUG_LOGS_ENABLED
    }
 ]
+EOF
+    fi
+
+    if [[ -n "${CADDY_OPTIONS}" ]]; then
+        echo "Applying custom options to Caddyfile"
+        cat <<EOF >>/caddy/Caddyfile
+$CADDY_OPTIONS
 EOF
     fi
 


### PR DESCRIPTION
We were having some issues with the request taking too long if the REST proxy contains large amounts of data, or the topic has many partitions. In those cases, Caddy always terminated the connection and we were given a Gateway timeout 502.

With this new option, one can add custom options to the Caddyfile, for instance to adjust the timeouts to the individual needs.

The options are only applied to the file if the env variable is specified by the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-topics-ui/102)
<!-- Reviewable:end -->
