### PR TITLE
fix(dataThreeView): Try to convert to JSON value to have nice UI pres…

### DIFF
--- a/src/kafka-topics/view/templates/data/tree/data-tree-view.module.js
+++ b/src/kafka-topics/view/templates/data/tree/data-tree-view.module.js
@@ -20,8 +20,23 @@ dataTreeViewModule.controller('dataTreeViewCtrl', function ($scope, $log, $base6
 
    $scope.$watch("data", function() {
         if($scope.data) {
-            $scope.rows = $scope.data; // because data is async/ly coming from an http call, we need to watch it, directive gets compiled from the beginning.
-            $scope.currentPage = 1
+          var data = $scope.data;
+            data = $scope.data.map((row) => {
+              var formattedRow = row;
+              if (typeof row.value === 'string') {
+                try {
+                  formattedRow = Object.assign({}, row, {
+                    value: (typeof row.value === 'string') ? JSON.parse(row.value) : row.value,
+                  });
+                } catch (e) {
+                  console.warn('Value is not JSON compatible', e);
+                }
+              }
+              return formattedRow;
+            });
+          
+          $scope.rows = data; // because data is async/ly coming from an http call, we need to watch it, directive gets compiled from the beginning.
+          $scope.currentPage = 1
         }
    })
 


### PR DESCRIPTION
### The facts
Currently, when we have Kafka messages with a key as string and a value as JSON object, the UI display the value as a string.

### The reason
The front-end app, first try to get an avro formatted response from kafka-rest if not available ask for a JSON formatted response and finally if JSON not available ask for binary response.

The problem is when we ask kafka-rest a JSON formatted response and the key of our messages are not object but strings, kafka-rest reject the call. So front-end app fallback to binary call but the result is that the value of our messages are returned as string and so not well displayed in the UI. (not openable)

### The fix
Try to convert the value of messages into JSON object if they are typeof string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-topics-ui/138)
<!-- Reviewable:end -->
