### PR TITLE
Avoid call on each topic when page loads

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ var clusters = [
       KAFKA_REST: "http://kafka-rest-ip:8082",
       MAX_BYTES: "50000",
       RECORD_POLL_TIMEOUT: "5000",
-      DEBUG_LOGS_ENABLED: true
+      DEBUG_LOGS_ENABLED: true,
+      LAZY_LOAD_TOPIC_META: false
     },
     {
       NAME: "dev",
@@ -76,7 +77,8 @@ var clusters = [
       MAX_BYTES: "50000",
       COLOR: "#141414", // Optional
       RECORD_POLL_TIMEOUT: "5000",
-      DEBUG_LOGS_ENABLED: true
+      DEBUG_LOGS_ENABLED: true,
+      LAZY_LOAD_TOPIC_META: false
     }
   ];
 ```
@@ -87,6 +89,7 @@ var clusters = [
 * Use `RECORD_POLL_TIMEOUT` to set the timeout in ms.
 * Use `COLOR` to set different header colors for each set up cluster.
 * Set `DEBUG_LOGS_ENABLED` to true to enable the debug logs.
+* Set `LAZY_LOAD_TOPIC_META` to true to lazy load topic meta information.
 
 ### CP Version support
 Latest release is for CP 3.2.0 and above.

--- a/env.js
+++ b/env.js
@@ -6,7 +6,8 @@ var clusters = [
       MAX_BYTES: "50000", 	// Sets the default maximum amount of bytes to fetch from each topic
       RECORD_POLL_TIMEOUT: "3000",
       COLOR: "#141414", // Optional
-      DEBUG_LOGS_ENABLED: true
+      DEBUG_LOGS_ENABLED: true,
+      LAZY_LOAD_TOPIC_META: false
     },
     {
       NAME: "dev",
@@ -14,6 +15,7 @@ var clusters = [
       MAX_BYTES: "50000",
       COLOR: "red",
       RECORD_POLL_TIMEOUT: "3000",
-      DEBUG_LOGS_ENABLED: true
+      DEBUG_LOGS_ENABLED: true,
+      LAZY_LOAD_TOPIC_META: false
     }
   ];

--- a/src/kafka-topics/list/compact-topics-list.html
+++ b/src/kafka-topics/list/compact-topics-list.html
@@ -13,7 +13,7 @@
         <!--TODO all topics, remove pagination-->
         <md-list-item dir-paginate="topic in normalTopics| orderBy:'topicName' | filter: search | itemsPerPage:100"
                       pagination-id="topics"
-                      ng-click="listClick(topic.topicName, topic.isControlTopic)"
+                      ng-click="listClick(topic, topic.isControlTopic)"
                       class="md-2-line"
                       ng-class="{ 'selectedListItem': topic.topicName == topicName }">
 

--- a/src/kafka-topics/list/topics-list.html
+++ b/src/kafka-topics/list/topics-list.html
@@ -28,7 +28,7 @@
         <md-list class="md-dense" flex>
           <md-list-item dir-paginate="topic in selectedTopics | orderBy:query.order | filter : search | itemsPerPage:topicsPerPage"
                         pagination-id="topics"
-                        ng-click="listClick(topic.topicName, displayingControlTopics)"
+                        ng-click="listClick(topic, displayingControlTopics)"
                         class="md-2-line"
                         current-page="topicsPage"
                         ng-class="{ 'selectedListItem': topicName == topic.topicName }">

--- a/src/kafka-topics/list/topics-list.module.js
+++ b/src/kafka-topics/list/topics-list.module.js
@@ -111,7 +111,7 @@ topicsListModule.controller('KafkaTopicsListCtrl', function ($scope, $location, 
   var itemsPerPage = (window.innerHeight - 280) / 48;
   Math.floor(itemsPerPage) < 3 ? $scope.topicsPerPage =3 : $scope.topicsPerPage = Math.floor(itemsPerPage);
 
-  $scope.listClick = function (topic, isControlTopic) {
+  function fillInTopicDetails(topic) {
     TopicsListFactory.getTopicDetails(topic.topicName, $scope.cluster.KAFKA_REST.trim()).then(function(res){
         var configsCounter = 0;
         angular.forEach(res.data.configs, function(value, key) { configsCounter++;});
@@ -119,6 +119,13 @@ topicsListModule.controller('KafkaTopicsListCtrl', function ($scope, $location, 
         topic.replication = res.data.partitions[0].replicas.length;
         topic.customConfig = configsCounter;
     });
+  }
+
+  $scope.listClick = function (topic, isControlTopic) {
+    // if lazy load is enabled, load meta on click.
+    if ($scope.cluster.LAZY_LOAD_TOPIC_META) {
+        fillInTopicDetails(topic);
+    }
     var urlType = (isControlTopic == true) ? 'c' : 'n';
     $location.path("cluster/" + $scope.cluster.NAME + "/topic/" + urlType + "/" + topic.topicName, true);
   }
@@ -135,6 +142,9 @@ topicsListModule.controller('KafkaTopicsListCtrl', function ($scope, $location, 
                 replication : "Unknown",
                 customConfig : null,
                 isControlTopic : checkIsControlTopic(topic)
+            }
+            if (!$scope.cluster.LAZY_LOAD_TOPIC_META) {
+                fillInTopicDetails(topicImproved);
             }
             topics.push(topicImproved);
             if (topics.length == allData.data.length) {


### PR DESCRIPTION
### Issue
The issue is when the page first loads it tries to make a call to `<REST_PROXY>/topics/<TOPIC_NAME>` for each topic. And when kafka has a lot of topics, this is problematic.

### Proposed fix
My proposal is to delay this call to only after user click on a specific topic. And because of this change, we now has to pass the topic object instead of topicName into listClick function.

### Note
This is a potential fix for #145 Unable to load all topics. I'm not very familiar with this repo so let me know if there's anything I need to change. This issue is blocking me from using this awesome kafka topic UI!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-topics-ui/146)
<!-- Reviewable:end -->
