### PR TITLE
Add support for multiple Kafka REST proxies via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 Browse Kafka topics and understand what's happening on your cluster. Find topics / view topic metadata / browse topic data (kafka messages) / view topic configuration / download data. This is a web tool for the [confluentinc/kafka-rest proxy](https://github.com/confluentinc/kafka-rest).
 
 ## Live Demo
+
 [kafka-topics-ui.demo.lenses.io](http://kafka-topics-ui.demo.lenses.io)
 
 ## Running it
@@ -37,11 +38,13 @@ then fall back to JSON, and finally fall back to Binary.
     bower install
     http-server -p 8080 .
 ```
+
 Web UI will be available at `http://localhost:8080`
 
 ### Nginx config
 
 If you use `nginx` to serve this ui, let angular manage routing with
+
 ```
     location / {
       add_header 'Access-Control-Allow-Origin' "$http_origin" always;
@@ -61,6 +64,7 @@ If you use `nginx` to serve this ui, let angular manage routing with
 ### Setup Kafka Rest clusters
 
 Use multiple Kafka Rest clusters in `env.js` :
+
 ```
 var clusters = [
     {
@@ -83,19 +87,27 @@ var clusters = [
   ];
 ```
 
+Alternatively, you can pass multiple proxies within `KAFKA_REST_PROXY_URL` env. variable by separating them with a space.
+
+```
+KAFKA_REST_PROXY_URL="http://kafka-rest-ip:8082 http://other-kafka-rest-ip:8082"
+```
+
 **Config**
 
-* Use `MAX_BYTES` to set the default maximum amount of bytes to fetch from each topic.
-* Use `RECORD_POLL_TIMEOUT` to set the timeout in ms.
-* Use `COLOR` to set different header colors for each set up cluster.
-* Set `DEBUG_LOGS_ENABLED` to true to enable the debug logs.
-* Set `LAZY_LOAD_TOPIC_META` to true to lazy load topic meta information.
+- Use `MAX_BYTES` to set the default maximum amount of bytes to fetch from each topic.
+- Use `RECORD_POLL_TIMEOUT` to set the timeout in ms.
+- Use `COLOR` to set different header colors for each set up cluster.
+- Set `DEBUG_LOGS_ENABLED` to true to enable the debug logs.
+- Set `LAZY_LOAD_TOPIC_META` to true to lazy load topic meta information.
 
 ### CP Version support
+
 Latest release is for CP 3.2.0 and above.
 
 For versions older than CP 3.2.0 you will need kafka topics ui [version 0.8.3](https://github.com/Landoop/kafka-topics-ui/releases/tag/v0.8.3).
 You can also build it from source by running:
+
 ```
     git clone https://github.com/Landoop/kafka-topics-ui.git
     cd kafka-topics-ui
@@ -111,8 +123,8 @@ fail to return messages for large topics. Although the default value is `1000`,
 a bug in the Kafka REST code prevents you from manually setting (depending on
 some other consumer options) a value lower than `30000`.
 
-
 ## Changelog
+
 [Here](https://github.com/Landoop/kafka-topics-ui/releases)
 
 ## Common Issues
@@ -140,11 +152,9 @@ The project is licensed under the [BSL](http://www.landoop.com/bsl) license.
 
 ## Relevant Projects
 
-* [schema-registry-ui](https://github.com/Landoop/schema-registry-ui), View, create, evolve and manage your Avro Schemas for multiple Kafka clusters
-* [kafka-connect-ui](https://github.com/Landoop/kafka-connect-ui), Set up and manage connectors for multiple connect clusters
-* [fast-data-dev](https://github.com/Landoop/fast-data-dev), Docker for Kafka developers (schema-registry,kafka-rest,zoo,brokers,landoop) 
-* [Landoop-On-Cloudera](https://github.com/Landoop/Landoop-On-Cloudera), Install and manage your kafka streaming-platform on you Cloudera CDH cluster
-
-
+- [schema-registry-ui](https://github.com/Landoop/schema-registry-ui), View, create, evolve and manage your Avro Schemas for multiple Kafka clusters
+- [kafka-connect-ui](https://github.com/Landoop/kafka-connect-ui), Set up and manage connectors for multiple connect clusters
+- [fast-data-dev](https://github.com/Landoop/fast-data-dev), Docker for Kafka developers (schema-registry,kafka-rest,zoo,brokers,landoop)
+- [Landoop-On-Cloudera](https://github.com/Landoop/Landoop-On-Cloudera), Install and manage your kafka streaming-platform on you Cloudera CDH cluster
 
 <img src="http://www.landoop.com/images/landoop-dark.svg" width="13" /> www.landoop.com

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-## Kafka Topics UI ##
+## Kafka Topics UI
 
 [![](https://images.microbadger.com/badges/image/landoop/kafka-topics-ui.svg)](http://microbadger.com/images/landoop/kafka-topics-ui)
 
@@ -27,8 +27,7 @@ Caddy server will proxy the traffic to the REST Proxy:
                landoop/kafka-topics-ui
 
 > **Important**: When proxying, for the `KAFKA_REST_PROXY_URL` you have to use
-> an IP address or a domain that can be resolved to it. **You can't use**
-> `localhost` even if you serve Kafka REST port from your localhost. The reason
+> an IP address or a domain that can be resolved to it. **You can't use** > `localhost` even if you serve Kafka REST port from your localhost. The reason
 > for this is that a docker container has its own network, so your _localhost_
 > is different from the container's _localhost_. As an example, if you are in
 > your home network and have an IP address of `192.168.5.65` and run Kafka REST
@@ -39,32 +38,44 @@ If your REST Proxy uses self-signed SSL certificates, you can use the
 `PROXY_SKIP_VERIFY=true` environment variable to instruct the proxy to
 not verify the backend TLS certificate.
 
+### Specifying multiple Kafka REST proxies
+
+You can specifying multiple Kafka proxies by separating proxy url's with a space. Consider the following example:
+
+    docker run --rm -it -p 8000:8000 \
+               -e "KAFKA_REST_PROXY_URL=http://kafka.rest.proxy.url http://other-kafka.rest.proxy.url" \
+               -e "PROXY=true" \
+               landoop/kafka-topics-ui
+
 # Configuration options
 
 ## Kafka Topics UI
 
 You can control most of Kafka Topics UI settings via environment variables:
 
- * `KAFKA_REST_PROXY_URL`
- * `MAX_BYTES` (default 50000)
- * `RECORD_POLL_TIMEOUT` (default 2000)
- * `DEBUG_LOGS_ENABLED` (default true).
+- `KAFKA_REST_PROXY_URL`
+- `MAX_BYTES` (default 50000)
+- `RECORD_POLL_TIMEOUT` (default 2000)
+- `DEBUG_LOGS_ENABLED` (default true).
 
 ## Docker Options
 
 - `PROXY=[true|false]`
 
   Whether to proxy REST Proxy endpoint via the internal webserver
+
 - `PROXY_SKIP_VERIFY=[true|false]`
 
   Whether to accept self-signed certificates when proxying REST Proxy
   via https
+
 - `PORT=[PORT]`
 
   The port number to use for kafka-topics-ui. The default is `8000`.
   Usually the main reason for using this is when you run the
   container with `--net=host`, where you can't use docker's publish
   flag (`-p HOST_PORT:8000`).
+
 - `CADDY_OPTIONS=[OPTIONS]`
 
   The webserver that powers the image is Caddy. Via this variable

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -43,15 +43,16 @@ EOF
     else
         echo "Kafka REST Proxy URL to $KAFKA_REST_PROXY_URL."
         cat <<EOF >/tmp/env.js
-var clusters = [
-   {
-     NAME:"default",
-     KAFKA_REST: "$KAFKA_REST_PROXY_URL",
+var proxies = "$KAFKA_REST_PROXY_URL";
+var clusters = proxies.split(' ').map((proxy, index) => {
+    return {
+     NAME:"instance-" + String(index + 1),
+     KAFKA_REST: proxy,
      MAX_BYTES: "$MAX_BYTES",
      RECORD_POLL_TIMEOUT: "$RECORD_POLL_TIMEOUT",
      DEBUG_LOGS_ENABLED: $DEBUG_LOGS_ENABLED
    }
-]
+})
 EOF
     fi
 


### PR DESCRIPTION
This pull request adds support for multiple Kafka REST proxies via environment variables.

Closes #152 