### PR TITLE
Update Caddy github URL in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache ca-certificates wget \
     && echo "progress = dot:giga" | tee /etc/wgetrc
 
 # Add and Setup Caddy webserver
-RUN wget "https://github.com/mholt/caddy/releases/download/v0.10.11/caddy_v0.10.11_linux_amd64.tar.gz" -O /caddy.tgz \
+RUN wget "https://github.com/caddyserver/caddy/releases/download/v0.10.11/caddy_v0.10.11_linux_amd64.tar.gz" -O /caddy.tgz \
     && mkdir caddy \
     && tar xzf caddy.tgz -C /caddy --no-same-owner \
     && rm -f /caddy.tgz


### PR DESCRIPTION
Same change with https://github.com/lensesio/kafka-connect-ui/pull/112.

Replaced https://github.com/mholt/caddy/releases/download/v0.10.11/caddy_v0.10.11_linux_amd64.tar.gz with https://github.com/caddyserver/caddy/releases/download/v0.10.11/caddy_v0.10.11_linux_amd64.tar.gz. 